### PR TITLE
Suggestion for new playbook: Delete default vwire configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ansible-playbooks
+# pan-ansible-playbooks
 
 [![ansible-lint](https://github.com/PaloAltoNetworks/ansible-playbooks/workflows/ansible-lint/badge.svg)](https://github.com/PaloAltoNetworks/ansible-playbooks/actions?query=workflow%3Aansible-lint)
 

--- a/delete_default_vwire.yml
+++ b/delete_default_vwire.yml
@@ -1,4 +1,23 @@
 ---
+# delete_default_vwire.yml - Deletes the default virtual wire configuration from a new device.
+#
+# Description
+# ===========
+#
+# Deletes the default virtual wire configuration from a new device. Useful to clean configuration from factory default
+# settings like 'rule1' security rule, 'trust' and 'untrust' zones and interface configuration.
+#
+# This playbook requires connection details for the device to be specified in the variables 'ip_address', 'username',
+# and 'password'.  These may be defined as host variables (see `host_vars/firewall.yml` for an example) or extra vars.
+#
+# Usage
+# =====
+#
+#   target: Target PAN-OS device, as named in the inventory.  See `host_vars/firewall.yml` for sample 
+#           definition of host variables.  Default value is 'firewall'.
+#
+
+---
 
 - name: Delete the factory default configuration from all firewalls
   hosts: all

--- a/delete_default_vwire.yml
+++ b/delete_default_vwire.yml
@@ -5,7 +5,7 @@
 # ===========
 #
 # Deletes the default virtual wire configuration from a new device. Useful to clean configuration from factory default
-# settings like 'rule1' security rule, 'trust' and 'untrust' zones and interface configuration.
+# settings like 'rule1' security rule, 'trust' and 'untrust' zones and virtual wire interface configuration.
 #
 # This playbook requires connection details for the device to be specified in the variables 'ip_address', 'username',
 # and 'password'.  These may be defined as host variables (see `host_vars/firewall.yml` for an example) or extra vars.
@@ -17,27 +17,20 @@
 #           definition of host variables.  Default value is 'firewall'.
 #
 
----
-
-- name: Delete the factory default configuration from all firewalls
-  hosts: all
-  gather_facts: no
+- hosts: '{{ target | default("firewall") }}'
   connection: local
 
-  roles:
-    - role: PaloAltoNetworks.paloaltonetworks
-
   vars:
-    provider:
-      ip_address: '{{ ansible_host }}'
-      port: '{{ port }}'
-      username: '{{ username }}'
-      password: '{{ password }}'
+    device:
+      ip_address: '{{ ip_address }}'
+      username: '{{ username | default(omit) }}'
+      password: '{{ password | default(omit) }}'
+      api_key: '{{ api_key | default(omit) }}'
 
   tasks:
     - name: Delete Security Rule "rule1"
       panos_type_cmd:
-        provider: '{{ provider }}'
+        provider: '{{ device }}'
         cmd: delete
         xpath: |
           /config/devices/entry[@name='localhost.localdomain']
@@ -46,7 +39,7 @@
 
     - name: Delete Virtual Wire "default-vwire"
       panos_type_cmd:
-        provider: '{{ provider }}'
+        provider: '{{ device }}'
         cmd: delete
         xpath: |
           /config/devices/entry[@name='localhost.localdomain']
@@ -54,7 +47,7 @@
 
     - name: Delete Zone "trust"
       panos_type_cmd:
-        provider: '{{ provider }}'
+        provider: '{{ device }}'
         cmd: delete
         xpath: |
           /config/devices/entry[@name='localhost.localdomain']
@@ -63,7 +56,7 @@
 
     - name: Delete Zone "untrust"
       panos_type_cmd:
-        provider: '{{ provider }}'
+        provider: '{{ device }}'
         cmd: delete
         xpath: |
           /config/devices/entry[@name='localhost.localdomain']
@@ -72,7 +65,7 @@
 
     - name: Delete interface "ethernet1/1"
       panos_type_cmd:
-        provider: '{{ provider }}'
+        provider: '{{ device }}'
         cmd: delete
         xpath: |
           /config/devices/entry[@name='localhost.localdomain']
@@ -80,7 +73,7 @@
 
     - name: Delete interface "ethernet1/2"
       panos_type_cmd:
-        provider: '{{ provider }}'
+        provider: '{{ device }}'
         cmd: delete
         xpath: |
           /config/devices/entry[@name='localhost.localdomain']

--- a/delete_default_vwire.yml
+++ b/delete_default_vwire.yml
@@ -1,0 +1,68 @@
+---
+
+- name: Delete the factory default configuration from all firewalls
+  hosts: all
+  gather_facts: no
+  connection: local
+
+  roles:
+    - role: PaloAltoNetworks.paloaltonetworks
+
+  vars:
+    provider:
+      ip_address: '{{ ansible_host }}'
+      port: '{{ port }}'
+      username: '{{ username }}'
+      password: '{{ password }}'
+
+  tasks:
+    - name: Delete Security Rule "rule1"
+      panos_type_cmd:
+        provider: '{{ provider }}'
+        cmd: delete
+        xpath: |
+          /config/devices/entry[@name='localhost.localdomain']
+          /vsys/entry[@name='vsys1']/rulebase/security/rules
+          /entry[@name='rule1']
+
+    - name: Delete Virtual Wire "default-vwire"
+      panos_type_cmd:
+        provider: '{{ provider }}'
+        cmd: delete
+        xpath: |
+          /config/devices/entry[@name='localhost.localdomain']
+          /network/virtual-wire/entry[@name='default-vwire']
+
+    - name: Delete Zone "trust"
+      panos_type_cmd:
+        provider: '{{ provider }}'
+        cmd: delete
+        xpath: |
+          /config/devices/entry[@name='localhost.localdomain']
+          /vsys/entry[@name='vsys1']
+          /zone/entry[@name='trust']
+
+    - name: Delete Zone "untrust"
+      panos_type_cmd:
+        provider: '{{ provider }}'
+        cmd: delete
+        xpath: |
+          /config/devices/entry[@name='localhost.localdomain']
+          /vsys/entry[@name='vsys1']
+          /zone/entry[@name='untrust']
+
+    - name: Delete interface "ethernet1/1"
+      panos_type_cmd:
+        provider: '{{ provider }}'
+        cmd: delete
+        xpath: |
+          /config/devices/entry[@name='localhost.localdomain']
+          /network/interface/ethernet/entry[@name='ethernet1/1']
+
+    - name: Delete interface "ethernet1/2"
+      panos_type_cmd:
+        provider: '{{ provider }}'
+        cmd: delete
+        xpath: |
+          /config/devices/entry[@name='localhost.localdomain']
+          /network/interface/ethernet/entry[@name='ethernet1/2']

--- a/delete_default_vwire.yml
+++ b/delete_default_vwire.yml
@@ -29,7 +29,7 @@
 
   tasks:
     - name: Delete Security Rule "rule1"
-      panos_type_cmd:
+      paloaltonetworks.panos.panos_type_cmd:
         provider: '{{ device }}'
         cmd: delete
         xpath: |
@@ -38,7 +38,7 @@
           /entry[@name='rule1']
 
     - name: Delete Virtual Wire "default-vwire"
-      panos_type_cmd:
+      paloaltonetworks.panos.panos_type_cmd:
         provider: '{{ device }}'
         cmd: delete
         xpath: |
@@ -46,7 +46,7 @@
           /network/virtual-wire/entry[@name='default-vwire']
 
     - name: Delete Zone "trust"
-      panos_type_cmd:
+      paloaltonetworks.panos.panos_type_cmd:
         provider: '{{ device }}'
         cmd: delete
         xpath: |
@@ -55,7 +55,7 @@
           /zone/entry[@name='trust']
 
     - name: Delete Zone "untrust"
-      panos_type_cmd:
+      paloaltonetworks.panos.panos_type_cmd:
         provider: '{{ device }}'
         cmd: delete
         xpath: |
@@ -64,7 +64,7 @@
           /zone/entry[@name='untrust']
 
     - name: Delete interface "ethernet1/1"
-      panos_type_cmd:
+      paloaltonetworks.panos.panos_type_cmd:
         provider: '{{ device }}'
         cmd: delete
         xpath: |
@@ -72,7 +72,7 @@
           /network/interface/ethernet/entry[@name='ethernet1/1']
 
     - name: Delete interface "ethernet1/2"
-      panos_type_cmd:
+      paloaltonetworks.panos.panos_type_cmd:
         provider: '{{ device }}'
         cmd: delete
         xpath: |


### PR DESCRIPTION
## Description

This playbook deletes parts of the default configuration which is shipped with new hardware Palo Alto Networks firewalls

## Motivation and Context

Palo Alto Networks firewalls are shipped with a default configuration, which is useless in the most use cases. Before you can do anything, the config often needs to be cleaned from specific elements to actually use the firewall or adopt it to Panorama and push a centrally managed configuration.

## How Has This Been Tested?

I have been using this playbook a lot in a customer project where I needed to configure 100+ firewalls with factory default settings. I was using Ansible 2.9 and Python 3.8 on Ubuntu 20.0.4 LTS (Focal Fossa).

## Types of changes

- New feature (non-breaking change which adds functionality)
