### PR TITLE
check for state in show ha state response

### DIFF
--- a/upgrade_ha.yml
+++ b/upgrade_ha.yml
@@ -124,8 +124,9 @@
       register: primary_state_sync
       retries: 10
       delay: 30
-      until: ( primary_state_sync.stdout | from_json).response.result.group["local-info"].state == 'passive' and
-             ( primary_state_sync.stdout | from_json).response.result.group["local-info"]["state-sync"] == 'Complete'
+      until: '"state" in ( primary_state_sync.stdout | from_json).response.result.group["local-info"] and
+             ( primary_state_sync.stdout | from_json).response.result.group["local-info"].state == "passive" and
+             ( primary_state_sync.stdout | from_json).response.result.group["local-info"]["state-sync"] == "Complete"'
 
     - name: Pause for verification
       pause:
@@ -176,5 +177,6 @@
       register: secondary_state_sync
       retries: 10
       delay: 30
-      until: ( secondary_state_sync.stdout | from_json).response.result.group["local-info"].state == 'passive' and
-             ( secondary_state_sync.stdout | from_json).response.result.group["local-info"]["state-sync"] == 'Complete'
+      until: '"state" in ( secondary_state_sync.stdout | from_json).response.result.group["local-info"] and 
+             ( secondary_state_sync.stdout | from_json).response.result.group["local-info"].state == "passive" and
+             ( secondary_state_sync.stdout | from_json).response.result.group["local-info"]["state-sync"] == "Complete"'


### PR DESCRIPTION


## Description

newly booted devices after an upgrade often return null output from the show ha state command for some time, which causes the 'state sync check' tasks to fail on a KeyError: ` 'dict object' has no attribute 'state'`. This adds a simple check to ensure the data is well-formed before performing additional logic.


## Motivation and Context

HA Upgrades fail with error:  ` 'dict object' has no attribute 'state'`

## How Has This Been Tested?

Tested on pair of PA-5220

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes


- Bug fix (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [*] I have updated the documentation accordingly.
- [*] I have read the **CONTRIBUTING** document.
- [*] I have added tests to cover my changes if appropriate.
- [*] All new and existing tests passed.
