### PR TITLE
Update session_report.j2

### DIFF
--- a/session_report.j2
+++ b/session_report.j2
@@ -8,6 +8,6 @@ Destination Zone: {{ session.to }}
 Destination: {{ session.dst }}
 Destination Port: {{ session.dport }}
 Application: {{ session.application }}
-Security Rule: {{ session['security-rule'] }}
+Security Rule: {{ session['security-rule'] | default('NONE')}}
 
 {% endfor %}


### PR DESCRIPTION
Not all sessions have associated security-rule (example: esp sessions for IPSEC tunnels).  If run against a firewall that terminates esp tunnels, the playbook will fail with "AnsibleUndefinedVariable: 'dict object' has no attribute 'security-rule'"}

## Description

Added default of NONE for cases where a session has no associated security-rule

## Motivation and Context

My firewall terminates IPSEC tunnels to other sites, meaning we have long-lasting esp sessions but which have no security-rule.   In this case the playbook fails 

## How Has This Been Tested?

I modified my local copy and ran it against my IPSEC tunnel terminating firewall, it executed correctly and I got "Security rule: NONE" in my output (for only the appropriate sessions) as expected.


## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
